### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/Knižnice (Libraries)/Atmega328_IO/keywords.txt
+++ b/Knižnice (Libraries)/Atmega328_IO/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Atmega328_IO	KEYWORD1 atmega 
+Atmega328_IO	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format